### PR TITLE
add updateCacheURI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You need a working bun installation as well as a working postgres database. It i
 
 You need a .env file with at least the following variables:
 - `CACHE_ROOT_DOMAIN`: The domain name of where your cache server should be available.
-- `AUTO_FIX_CACHE_ROOT_DOMAIN`: If this stands on false the `CACHE_ROOT_DOMAIN` is only used for new caches. If this is set to true (which is default) all caches get the new domain on startup. 
+- `AUTO_FIX_CACHE_ROOT_DOMAIN`: If this is set to false the `CACHE_ROOT_DOMAIN` is only used for new caches. If this is set to true (which is the default) all caches get the new domain on startup. 
 - `CACHE_FILESYSTEM_DIR`: The directory where the cache files should be stored (Careful, there will be a lot of read and writes happening at this dir, so choose accordingly).
 - `POSTGRES_HOST`: Host of the postgresql server.
 - `POSTGRES_PORT`: Port of the postgresql server.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ You need a working bun installation as well as a working postgres database. It i
 
 You need a .env file with at least the following variables:
 - `CACHE_ROOT_DOMAIN`: The domain name of where your cache server should be available.
+- `AUTO_FIX_CACHE_ROOT_DOMAIN`: If this stands on false the `CACHE_ROOT_DOMAIN` is only used for new caches. If this is set to true (which is default) all caches get the new domain on startup. 
 - `CACHE_FILESYSTEM_DIR`: The directory where the cache files should be stored (Careful, there will be a lot of read and writes happening at this dir, so choose accordingly).
 - `POSTGRES_HOST`: Host of the postgresql server.
 - `POSTGRES_PORT`: Port of the postgresql server.

--- a/index.ts
+++ b/index.ts
@@ -61,6 +61,13 @@ await Database.getAllCaches().then(async (caches:Array<cache>)=>{
     }
     caches = await Database.getAllCaches()
     for (const cache of caches) {
+        //Updateing CACHE_ROOT_DOMAIN if needed
+        if(cache.uri != process.env.CACHE_ROOT_DOMAIN && process.env.AUTO_FIX_CACHE_ROOT_DOMAIN !== "false"){
+          console.log("Updating CACHE_ROOT_DOMAIN for cache \"" + cache.name + "\"")
+          await Database.updateCacheURI(process.env.CACHE_ROOT_DOMAIN, cache.id)
+        }
+
+        //Create Key if needed
         if(cache.allowedKeys.length === 0){
             const cacheKey = makeApiKey(cache.name)
             console.log(`Initial Key for cache ${cache.name}: ${cacheKey}`)
@@ -120,7 +127,6 @@ for(const cache of await Database.getAllCaches()){
         }
     }
 }
-
 
 app.use(raw())
 

--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,7 @@ await Database.getAllCaches().then(async (caches:Array<cache>)=>{
     }
     caches = await Database.getAllCaches()
     for (const cache of caches) {
-        //Updateing CACHE_ROOT_DOMAIN if needed
+        //Updating CACHE_ROOT_DOMAIN if needed
         if(cache.uri != process.env.CACHE_ROOT_DOMAIN && process.env.AUTO_FIX_CACHE_ROOT_DOMAIN !== "false"){
           console.log("Updating CACHE_ROOT_DOMAIN for cache \"" + cache.name + "\"")
           await Database.updateCacheURI(process.env.CACHE_ROOT_DOMAIN, cache.id)

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -299,4 +299,10 @@ export default class Database {
             INSERT INTO cache.request (hash, cache_id, type) VALUES($1, $2, $3)
         `,[hashID, cacheID, type])
     }
+
+    public async updateCacheURI(uri:string, cacheID:number):Promise<void>{
+      await this.db.query(`
+          UPDATE cache.caches SET uri = $1 WHERE id = $2
+      `, [uri, cacheID])
+    }
 }


### PR DESCRIPTION
fixes #13 

After this patch the cache uri gets overriden if `CACHE_ROOT_DOMAIN` does not match the cache uri **AND** `AUTO_FIX_CACHE_ROOT_DOMAIN` is set to true, witch is the default.