### PR TITLE
feat(DB): Moved API Keys to use uuids instead of jwt tokens

### DIFF
--- a/utils/apiKeys.ts
+++ b/utils/apiKeys.ts
@@ -1,6 +1,7 @@
-import jwt from 'jsonwebtoken';
 import 'dotenv/config';
+import { randomUUIDv7 } from 'bun'
 export function makeApiKey(cacheName:string):string{
-    //We can be sure that this exists as we check for it in the index.ts file
-    return jwt.sign({name:cacheName}, process.env.CACHE_JWT_SECRET as string)
+
+    const uid = randomUUIDv7();
+    return `${cacheName}-${uid}`;
 }

--- a/utils/middlewares/auth.ts
+++ b/utils/middlewares/auth.ts
@@ -13,27 +13,6 @@ export async function isAuthenticated (req: any, res: any, next: any):Promise<bo
             res.status(403).json({ message: 'Forbidden' });
             return false
         }
-        // Verify the token
-        // Check if the token is valid
-        let decoded:any
-        try{
-            decoded = jwt.verify(token, process.env.CACHE_JWT_SECRET as string);
-        }
-        catch(e){
-            //Return a 403 error if the token is invalid
-            res.status(403).json({ message: 'Forbidden' });
-            return false;
-        }
-        if (!decoded) {
-            res.status(403).json({ message: 'Forbidden' });
-            return false
-        }
-
-        // Check if the decoded token  matches the cache name
-        if (!decoded.name) {
-            res.status(403).json({ message: 'Forbidden' });
-            return false
-        }
 
         // If everything is fine so far we can check if this api key is allowed to push this cache
         // Check if the cache exists
@@ -54,8 +33,6 @@ export async function isAuthenticated (req: any, res: any, next: any):Promise<bo
                 res.status(403).json({ message: 'Forbidden' });
                 return false
             }
-
-            //TODO: Figure out a more processor efficient way to do this as this could be bad for performance if checking a lot of keys
             /*
             * This verifies that a given jwt token matches the hash stored in the database using the Argon2 password hashing algorithm.
             * */


### PR DESCRIPTION
This removes JWTs from the Codebase as they aren't needed and didn't provide any benefit. They are being replaced by a uuid combined with the cache name as the api key. This was done because it's needed for the controller to create keys without having to know the jwt secret of the cache. 